### PR TITLE
dotnet: Handle multiple csproj files

### DIFF
--- a/dotnet/flatpak-dotnet-generator.py
+++ b/dotnet/flatpak-dotnet-generator.py
@@ -15,7 +15,7 @@ import tempfile
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('output', help='The output JSON sources file')
-    parser.add_argument('project', help='The project file')
+    parser.add_argument('project', nargs='+', help='The project file(s)')
     parser.add_argument('--runtime', '-r', help='The target runtime to restore packages for')
     parser.add_argument('--destdir',
                         help='The directory the generated sources file will save sources to',
@@ -29,14 +29,15 @@ def main():
         if args.runtime:
             runtime_args.extend(('-r', args.runtime))
 
-        subprocess.run([
-            'flatpak', 'run',
-            '--env=DOTNET_CLI_TELEMETRY_OPTOUT=true',
-            '--env=DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true',
-            '--command=sh', '--runtime=org.freedesktop.Sdk//21.08', '--share=network',
-            '--filesystem=host', 'org.freedesktop.Sdk.Extension.dotnet6//21.08', '-c',
-            'PATH="${PATH}:/usr/lib/sdk/dotnet6/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/sdk/dotnet6/lib" exec dotnet restore "$@"',
-            '--', '--packages', tmp, args.project] + runtime_args)
+        for project in args.project:
+            subprocess.run([
+                'flatpak', 'run',
+                '--env=DOTNET_CLI_TELEMETRY_OPTOUT=true',
+                '--env=DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true',
+                '--command=sh', '--runtime=org.freedesktop.Sdk//21.08', '--share=network',
+                '--filesystem=host', 'org.freedesktop.Sdk.Extension.dotnet6//21.08', '-c',
+                'PATH="${PATH}:/usr/lib/sdk/dotnet6/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/sdk/dotnet6/lib" exec dotnet restore "$@"',
+                '--', '--packages', tmp, project] + runtime_args)
 
         for path in Path(tmp).glob('**/*.nupkg.sha512'):
             name = path.parent.parent.name


### PR DESCRIPTION
- Allows generator to create a single sources list from multiple .csproj files. A dependency may contain many .csproj files, but it makes sense to group the sources into one .json file for the dependency.
e.g. flatpak-dotnet-generator output.json library1.csproj library2.csproj